### PR TITLE
Add freeze/unfreeze feature

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -5,6 +5,10 @@
 - [Eosio CDT 4.1.0](https://github.com/AntelopeIO/cdt/releases/download/v4.1.0/cdt_4.1.0-1_amd64.deb)
 - Make (`apt install -y build-essential`)
 
+If you want to spin up a local testnet:
+
+- [Spring v1.0.2](https://github.com/AntelopeIO/spring/releases/tag/v1.0.2)
+
 ### Spin up a local testnet and try it out
 
 ```bash

--- a/cpp/contracts/xerc20.token.cpp
+++ b/cpp/contracts/xerc20.token.cpp
@@ -2,8 +2,8 @@
 
 namespace eosio {
 
-void xtoken::create( const name&   issuer,
-                    const asset&  maximum_supply )
+void xtoken::create(const name&   issuer,
+                    const asset&  maximum_supply)
 {
 
     require_auth( get_self() );
@@ -48,6 +48,7 @@ void xtoken::mint( const name& caller, const name& to, const asset& quantity, co
     if (caller != lockbox) {
       auto bridge = *itr;
       auto current_limit = minting_current_limit_of(bridge);
+
       check(quantity <= current_limit, "xerc20_assert: not hight enough limits");
       use_minter_limits(bridge, quantity);
 
@@ -114,12 +115,20 @@ void xtoken::burn( const name& caller, const asset& quantity, const string& memo
 
 }
 
+bool xtoken::is_frozen(const name& account) {
+   frozens _frozens(get_self(), get_self().value);
+   const auto& itr = _frozens.find(account.value);
+
+   return itr != _frozens.end();
+}
 
 void xtoken::transfer( const name&    from,
                       const name&    to,
                       const asset&   quantity,
                       const string&  memo )
 {
+    check(!is_frozen(from), "from account is frozen");
+    check(!is_frozen(to), "to account is frozen");
     check( from != to, "cannot transfer to self" );
     require_auth( from );
     check( is_account( to ), "to account does not exist");
@@ -338,6 +347,67 @@ void xtoken::use_burner_limits(xtoken::bridge_model& bridge, const asset& change
    asset current_limit = burning_current_limit_of(bridge);
    bridge.burning_timestamp = current_block_time().to_time_point().sec_since_epoch();
    bridge.burning_current_limit = current_limit - change;
+}
+
+void xtoken::setfreezeacc(const name& freezing_account) {
+   require_auth(get_self());
+   check(is_account(freezing_account), "invalid freezing account");
+
+   freezing_account_singleton _freezing_account(get_self(), get_self().value);
+   _freezing_account.set(freezing_account, get_self());
+}
+
+name xtoken::check_freezing_requirements(const name& self) {
+   freezing_account_singleton _freezing_account(self, self.value);
+   auto freezing_account = _freezing_account.get_or_default(name(0));
+
+   check(freezing_account != name(0), "freezing not enabled");
+
+   require_auth(freezing_account);
+
+   return freezing_account;
+}
+
+void xtoken::freeze(const name& account) {
+   check(is_account(account), "invalid account name");
+   check_freezing_requirements(get_self());
+
+   frozens _frozens(get_self(), get_self().value);
+
+   auto itr = _frozens.find(account.value);
+   check(itr == _frozens.end(), "account already frozen");
+
+   _frozens.emplace(get_self(), [&](auto& r) {
+      r.account = account;
+   });
+}
+
+void xtoken::unfreeze(const name& account) {
+   check(is_account(account), "invalid account name");
+   check_freezing_requirements(get_self());
+
+   frozens _frozens(get_self(), get_self().value);
+
+   auto itr = _frozens.find(account.value);
+   check(itr != _frozens.end(), "account not frozen");
+
+   _frozens.erase(itr);
+}
+
+void xtoken::pullfrozen(const name& frozen, const name& to, const asset& quantity) {
+   check(is_account(frozen), "invalid account name");
+   check(is_account(to), "invalid recipient name");
+   check(quantity.symbol.is_valid(), "invalid quantity symbol");
+
+   auto freezing_account = check_freezing_requirements(get_self());
+
+   frozens _frozens(get_self(), get_self().value);
+   auto itr = _frozens.find(frozen.value);
+
+   check(itr != _frozens.end(), "given account is not frozen");
+
+   sub_balance(frozen, quantity);
+   add_balance(to, quantity, to);
 }
 } /// namespace eosio
 

--- a/cpp/contracts/xerc20.token.cpp
+++ b/cpp/contracts/xerc20.token.cpp
@@ -2,8 +2,8 @@
 
 namespace eosio {
 
-void xtoken::create(const name&   issuer,
-                    const asset&  maximum_supply)
+void xtoken::create( const name&   issuer,
+                    const asset&  maximum_supply )
 {
 
     require_auth( get_self() );
@@ -48,7 +48,6 @@ void xtoken::mint( const name& caller, const name& to, const asset& quantity, co
     if (caller != lockbox) {
       auto bridge = *itr;
       auto current_limit = minting_current_limit_of(bridge);
-
       check(quantity <= current_limit, "xerc20_assert: not hight enough limits");
       use_minter_limits(bridge, quantity);
 
@@ -369,8 +368,8 @@ name xtoken::check_freezing_requirements(const name& self) {
 }
 
 void xtoken::freeze(const name& account) {
-   check(is_account(account), "invalid account name");
    check_freezing_requirements(get_self());
+   check(is_account(account), "invalid account name");
 
    frozens _frozens(get_self(), get_self().value);
 
@@ -383,8 +382,8 @@ void xtoken::freeze(const name& account) {
 }
 
 void xtoken::unfreeze(const name& account) {
-   check(is_account(account), "invalid account name");
    check_freezing_requirements(get_self());
+   check(is_account(account), "invalid account name");
 
    frozens _frozens(get_self(), get_self().value);
 
@@ -395,11 +394,10 @@ void xtoken::unfreeze(const name& account) {
 }
 
 void xtoken::pullfrozen(const name& frozen, const name& to, const asset& quantity) {
+   auto freezing_account = check_freezing_requirements(get_self());
    check(is_account(frozen), "invalid account name");
    check(is_account(to), "invalid recipient name");
    check(quantity.symbol.is_valid(), "invalid quantity symbol");
-
-   auto freezing_account = check_freezing_requirements(get_self());
 
    frozens _frozens(get_self(), get_self().value);
    auto itr = _frozens.find(frozen.value);

--- a/cpp/contracts/xerc20.token.hpp
+++ b/cpp/contracts/xerc20.token.hpp
@@ -72,7 +72,6 @@ namespace eosio {
             return itr->burning_max_limit;
          }
 
-         using action_transfer = action_wrapper<"transfer"_n, &xtoken::transfer>;
       private:
          uint64_t const DURATION = 86400; // 1 days in seconds
 

--- a/cpp/contracts/xerc20.token.hpp
+++ b/cpp/contracts/xerc20.token.hpp
@@ -30,6 +30,14 @@ namespace eosio {
 
          ACTION close(const name& owner, const symbol& symbol);
 
+         ACTION setfreezeacc(const name& freezing_account);
+
+         ACTION freeze(const name& account);
+
+         ACTION unfreeze(const name& account);
+
+         ACTION pullfrozen(const name& account, const name& to, const asset& quantity);
+
          static asset get_supply(const name& token_contract_account, const symbol_code& sym_code) {
             stats statstable(token_contract_account, sym_code.raw());
             const auto& st = statstable.get(sym_code.raw(), "invalid supply symbol code");
@@ -64,8 +72,17 @@ namespace eosio {
             return itr->burning_max_limit;
          }
 
+         using action_transfer = action_wrapper<"transfer"_n, &xtoken::transfer>;
       private:
          uint64_t const DURATION = 86400; // 1 days in seconds
+
+         TABLE frozen_accounts {
+            name     account;
+
+            uint64_t primary_key() const {
+               return account.value;
+            }
+         };
 
          TABLE account {
             asset    balance;
@@ -108,18 +125,22 @@ namespace eosio {
 
          typedef eosio::multi_index< "accounts"_n, account > accounts;
          typedef eosio::multi_index< "stat"_n, currency_stats > stats;
+         typedef eosio::multi_index< "frozensacc"_n, frozen_accounts > frozens;
          typedef eosio::multi_index< "bridges"_n, bridge_model,
             indexed_by< "bysymbol"_n, const_mem_fun<bridge_model, uint64_t, &bridge_model::secondary_key>
          > > bridges;
 
          using lockbox_singleton = singleton<"lockbox"_n, name>;
+         using freezing_account_singleton = singleton<"freezeacc"_n, name>;
 
+         bool is_frozen(const name& account);
          asset minting_current_limit_of(bridge_model& bridge);
          asset burning_current_limit_of(bridge_model& bridge);
          void use_minter_limits(bridge_model& bridge, const asset& change);
          void use_burner_limits(bridge_model& bridge, const asset& change);
          void change_minter_limit(bridge_model& bridge, const asset& limit);
          void change_burner_limit(bridge_model& bridge, const asset& limit);
+         name check_freezing_requirements(const name& self);
          bridge_model get_empty_bridge_model(const name& account, const symbol& symbol);
          asset calculate_new_current_limit(const asset& limit, const asset& old_limit, const asset& current_limit);
          asset get_current_limit(const asset& current_limit, const asset& max_limit, const uint64_t timestamp, const uint64_t rate_per_second);

--- a/cpp/test/utils/errors.js
+++ b/cpp/test/utils/errors.js
@@ -1,11 +1,20 @@
-const SYMBOL_ALREADY_EXISTS = 'eosio_assert: token with symbol already exists'
-const ACCOUNT_DOES_NOT_EXIST = 'eosio_assert: token account does not exist'
-const INSUFFICIENT_BALANCE_SET = 'eosio_assert: [set allowance]: balance is lower than the allowance to be set'
-const INSUFFICIENT_BALANCE_INC = 'eosio_assert: [increase allowance]: balance is lower than the allowance to be set'
-const NO_ALLOWANCE_SET = 'eosio_assert: No allowance set for this node'
+const eosio_assert = _str => `eosio_assert: ${_str}`
+
+const SYMBOL_ALREADY_EXISTS = eosio_assert('token with symbol already exists')
+const ACCOUNT_DOES_NOT_EXIST = eosio_assert('token account does not exist')
+const INSUFFICIENT_BALANCE_SET = eosio_assert(
+  '[set allowance]: balance is lower than the allowance to be set',
+)
+const INSUFFICIENT_BALANCE_INC = eosio_assert(
+  '[increase allowance]: balance is lower than the allowance to be set',
+)
+const NO_ALLOWANCE_SET = eosio_assert('No allowance set for this node')
 
 const AUTH_MISSING = _account => `missing required authority ${_account}`
-const SYMBOL_NOT_FOUND = 'eosio_assert: symbol not found'
+const SYMBOL_NOT_FOUND = eosio_assert('symbol not found')
+
+const FROM_ACCOUNT_IS_FROZEN = eosio_assert('from account is frozen')
+const TO_ACCOUNT_IS_FROZEN = eosio_assert('to account is frozen')
 
 module.exports = {
   AUTH_MISSING,
@@ -15,4 +24,6 @@ module.exports = {
   INSUFFICIENT_BALANCE_SET,
   INSUFFICIENT_BALANCE_INC,
   NO_ALLOWANCE_SET,
+  FROM_ACCOUNT_IS_FROZEN,
+  TO_ACCOUNT_IS_FROZEN,
 }

--- a/cpp/test/xerc20.token.freezing.test.js
+++ b/cpp/test/xerc20.token.freezing.test.js
@@ -1,0 +1,173 @@
+const { expect } = require('chai')
+const { deploy } = require('./utils/deploy')
+const { getSingletonInstance } = require('./utils/eos-ext')
+const { Blockchain, expectToThrow } = require('@eosnetwork/vert')
+const { active, getAccountCodeRaw, precision } = require('./utils/eos-ext')
+const errors = require('./utils/errors')
+const { substract } = require('./utils/wharfkit-ext')
+const { getAccountsBalances } = require('./utils/get-token-balance')
+
+TABLE_FREEZING_ACCOUNT = 'freezeacc'
+
+describe('xerc20.token - Freezing capabilities tests', () => {
+  describe('Cumulative tests', () => {
+    const symbol = 'TKN'
+    const maxSupply = 500000000
+    const blockchain = new Blockchain()
+
+    const user = 'user'
+    const evil = 'evil'
+    const issuer = 'issuer'
+    const recipient = 'recipient'
+    const lockbox = 'lockbox'
+    const freezingAccount = 'freezer'
+
+    const xerc20 = {
+      symbol: `X${symbol}`,
+      account: `x${symbol.toLowerCase()}.token`,
+      maxSupply: `${maxSupply}.0000 X${symbol}`,
+      contract: null,
+    }
+
+    const memo = ''
+    const evilInitialBalance = `100.0000 ${xerc20.symbol}`
+    const stolenAmount = `66.0000 ${xerc20.symbol}`
+    const transfereableAmount = substract(evilInitialBalance, stolenAmount)
+
+    before(async () => {
+      blockchain.createAccounts(
+        user,
+        issuer,
+        evil,
+        recipient,
+        lockbox,
+        freezingAccount,
+      )
+      xerc20.contract = deploy(
+        blockchain,
+        xerc20.account,
+        'contracts/build/xerc20.token',
+      )
+    })
+
+    const initialSetup = async () => {
+      const mintingLimit = `1000.0000 ${xerc20.symbol}`
+      const burningLimit = `600.0000 ${xerc20.symbol}`
+
+      await xerc20.contract.actions
+        .create([issuer, xerc20.maxSupply])
+        .send(active(xerc20.account))
+
+      await xerc20.contract.actions
+        .setlimits([xerc20.account, mintingLimit, burningLimit])
+        .send(active(xerc20.account))
+
+      await xerc20.contract.actions.setlockbox([lockbox]).send()
+    }
+
+    it("Only contract's active owner can set the freezing address", async () => {
+      await initialSetup()
+
+      let action = xerc20.contract.actions
+        .setfreezeacc([freezingAccount])
+        .send(active(evil))
+
+      await expectToThrow(action, errors.AUTH_MISSING(xerc20.account))
+
+      await xerc20.contract.actions
+        .setfreezeacc([freezingAccount])
+        .send(active(xerc20.account))
+
+      const freezingAccountSingleton = getSingletonInstance(
+        xerc20.contract,
+        TABLE_FREEZING_ACCOUNT,
+      )
+
+      expect(freezingAccountSingleton).to.be.equal(freezingAccount)
+    })
+
+    it('Only the freezing account can call the freezing actions', async () => {
+      const amount = `100.0000 ${xerc20.symbol}`
+      let action = xerc20.contract.actions.freeze([user]).send(active(evil))
+
+      await expectToThrow(action, errors.AUTH_MISSING(freezingAccount))
+
+      action = xerc20.contract.actions
+        .pullfrozen([user, evil, amount])
+        .send(active(evil))
+
+      await expectToThrow(action, errors.AUTH_MISSING(freezingAccount))
+
+      action = xerc20.contract.actions.unfreeze([user]).send(active(evil))
+
+      await expectToThrow(action, errors.AUTH_MISSING(freezingAccount))
+    })
+
+    it('Should freeze an account successfully', async () => {
+      await xerc20.contract.actions
+        .mint([xerc20.account, evil, evilInitialBalance, memo])
+        .send(active(xerc20.account))
+
+      await xerc20.contract.actions
+        .transfer([evil, recipient, transfereableAmount, memo])
+        .send(active(evil))
+
+      let balances = getAccountsBalances([evil, recipient], [xerc20])
+
+      expect(balances[recipient][xerc20.symbol]).to.be.equal(
+        transfereableAmount.toString(),
+      )
+
+      await xerc20.contract.actions.freeze([evil]).send(active(freezingAccount))
+
+      let rows = xerc20.contract.tables
+        .frozensacc(getAccountCodeRaw(xerc20.account))
+        .getTableRow(getAccountCodeRaw(evil))
+
+      expect(rows.account).to.be.equal(evil)
+    })
+
+    it('Should not able to transfer/receive funds after freezing', async () => {
+      let action = xerc20.contract.actions
+        .transfer([evil, recipient, transfereableAmount, memo])
+        .send(active(evil))
+
+      await expectToThrow(action, errors.FROM_ACCOUNT_IS_FROZEN)
+
+      action = xerc20.contract.actions
+        .transfer([recipient, evil, transfereableAmount, memo])
+        .send(active(evil))
+
+      await expectToThrow(action, errors.TO_ACCOUNT_IS_FROZEN)
+    })
+
+    it('Should withdraw the stolen amount successfully', async () => {
+      await xerc20.contract.actions
+        .pullfrozen([evil, freezingAccount, stolenAmount])
+        .send(active(freezingAccount))
+
+      const after = getAccountsBalances([evil, freezingAccount], [xerc20])
+
+      expect(after[evil][xerc20.symbol]).to.be.equal(`0.0000 ${xerc20.symbol}`)
+      expect(after[freezingAccount][xerc20.symbol]).to.be.equal(stolenAmount)
+    })
+
+    it('Should unfreeze an account successfully', async () => {
+      let rows = xerc20.contract.tables
+        .frozensacc(getAccountCodeRaw(xerc20.account))
+        .getTableRow(getAccountCodeRaw(evil))
+
+      expect(rows.account).to.be.equal(evil)
+
+      await xerc20.contract.actions
+        .unfreeze([evil])
+        .send(active(freezingAccount))
+
+      rows = xerc20.contract.tables
+        .frozensacc(getAccountCodeRaw(xerc20.account))
+        .getTableRow(getAccountCodeRaw(evil))
+
+      expect(rows).to.be.undefined
+    })
+  })
+})

--- a/solidity/hardhat.config.cjs
+++ b/solidity/hardhat.config.cjs
@@ -35,7 +35,13 @@ module.exports = {
       },
       {
         version: '0.8.25',
-        settings: { evmVersion: 'cancun' },
+        settings: {
+          optimizer: {
+            runs: 200,
+            enabled: true,
+          },
+          evmVersion: 'cancun',
+        },
       },
     ],
   },

--- a/solidity/src/contracts/XERC20-PTokenNoGSNCompat.sol
+++ b/solidity/src/contracts/XERC20-PTokenNoGSNCompat.sol
@@ -51,6 +51,18 @@ contract XERC20PTokenNoGSNCompat is
    */
   mapping(address => Bridge) public bridges;
 
+  address public freezingAddress;
+
+  bool public freezingEnabled;
+
+  mapping(address => bool) public frozen;
+
+  modifier onlyWithFreezeCapabilities(address sender) {
+    require(freezingEnabled, "Freeze capabilities are disabled");
+    require(freezingAddress == sender, "Only freezing address allowed");
+    _;
+  }
+
   /**
    * @notice This is for re-initialize the contract with the new owner
    * @param owner_ new owner of the contract
@@ -61,11 +73,30 @@ contract XERC20PTokenNoGSNCompat is
    * with the one already declared in PTokenNoGSNStorage.
    */
   // solhint-disable-next-line
-  function initializeV2(address owner_) public reinitializer(2) {
+  function initializeV2(address owner_, bool freezingEnabled_) public reinitializer(2) {
     // This is what is being performed by the ERC20Permit
     // contract inherited by the XERC20 immutable version
     __EIP712_init(_name, "1");
     _owner = owner_;
+    freezingEnabled = freezingEnabled_;
+  }
+
+  function freezeAddress(address addressToFreeze) public onlyWithFreezeCapabilities(msg.sender) {
+    frozen[addressToFreeze] = true;
+  }
+
+  function unfreezeAddress(address addressToUnfreeze) public onlyWithFreezeCapabilities(msg.sender) {
+    frozen[addressToUnfreeze] = false;
+  }
+
+  function withdrawFrozenAssets(address frozenAddress, address to, uint256 amount) public onlyWithFreezeCapabilities(msg.sender) {
+    require(frozen[frozenAddress], "Given address has not been freezed");
+
+    _transfer(frozenAddress, to, amount);
+  }
+
+  function setFreezingAddress(address freezingAddress_) public onlyOwner {
+    freezingAddress = freezingAddress_;
   }
 
   /**
@@ -399,6 +430,8 @@ contract XERC20PTokenNoGSNCompat is
   }
 
   function _transfer(address from, address to, uint256 amount) internal {
+      require(!freezingEnabled || !frozen[from] || freezingAddress == msg.sender, "owner is frozen"); // NOTE: freezing feat
+      require(!freezingEnabled || !frozen[to] || freezingAddress == msg.sender, "recipient is frozen"); // NOTE: freezing feat
       require(from != address(0), "ERC20: transfer from the zero address");
       require(to != address(0), "ERC20: transfer to the zero address");
 

--- a/solidity/src/contracts/XERC20.sol
+++ b/solidity/src/contracts/XERC20.sol
@@ -27,6 +27,18 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    */
   mapping(address => Bridge) public bridges;
 
+  address public freezingAddress;
+
+  bool public immutable freezingEnabled;
+
+  mapping(address => bool) public frozen;
+
+  modifier onlyWithFreezeCapabilities(address sender) {
+    require(freezingEnabled, "Freeze capabilities are disabled");
+    require(freezingAddress == sender, "Freezing address is not set");
+    _;
+  }
+
   /**
    * @notice Constructs the initial config of the XERC20
    *
@@ -35,8 +47,27 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
    * @param _factory The factory which deployed this contract
    */
 
-  constructor(string memory _name, string memory _symbol, address _factory) ERC20(_name, _symbol) ERC20Permit(_name) Ownable(_factory) {
+  constructor(string memory _name, string memory _symbol, address _factory, bool _freezingEnabled) ERC20(_name, _symbol) ERC20Permit(_name) Ownable(_factory) {
     FACTORY = _factory;
+    freezingEnabled = _freezingEnabled;
+  }
+
+  function freezeAddress(address addressToFreeze) public onlyWithFreezeCapabilities(msg.sender) {
+    frozen[addressToFreeze] = true;
+  }
+
+  function unfreezeAddress(address addressToUnfreeze) public onlyWithFreezeCapabilities(msg.sender) {
+    frozen[addressToUnfreeze] = false;
+  }
+
+  function withdrawFrozenAssets(address frozenAddress, address to, uint256 amount) public onlyWithFreezeCapabilities(msg.sender) {
+    require(frozen[frozenAddress], "Given address has not been freezed");
+
+    super._update(frozenAddress, to, amount);
+  }
+
+  function setFreezingAddress(address freezingAddress_) public onlyOwner {
+    freezingAddress = freezingAddress_;
   }
 
   /**
@@ -290,5 +321,11 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
       _useMinterLimits(_caller, _amount);
     }
     _mint(_user, _amount);
+  }
+
+  function _update(address from, address to, uint256 value) internal virtual override {
+    require(!frozen[from], "owner is frozen");
+    require(!frozen[to], "recipient is frozen");
+    super._update(from, to, value);
   }
 }

--- a/solidity/src/contracts/XERC20.sol
+++ b/solidity/src/contracts/XERC20.sol
@@ -63,6 +63,10 @@ contract XERC20 is ERC20, Ownable, IXERC20, ERC20Permit {
   function withdrawFrozenAssets(address frozenAddress, address to, uint256 amount) public onlyWithFreezeCapabilities(msg.sender) {
     require(frozen[frozenAddress], "Given address has not been freezed");
 
+    // Prevent freezing address to mint/burn (increase the total supply)
+    require(frozenAddress != address(0), "invalid frozen address");
+    require(to != address(0), "invalid destination address");
+
     super._update(frozenAddress, to, amount);
   }
 

--- a/solidity/src/contracts/XERC20Factory.sol
+++ b/solidity/src/contracts/XERC20Factory.sol
@@ -41,9 +41,10 @@ contract XERC20Factory is IXERC20Factory {
     string memory _symbol,
     uint256[] memory _minterLimits,
     uint256[] memory _burnerLimits,
-    address[] memory _bridges
+    address[] memory _bridges,
+    bool _freezingEnabled
   ) external returns (address _xerc20) {
-    _xerc20 = _deployXERC20(_name, _symbol, _minterLimits, _burnerLimits, _bridges);
+    _xerc20 = _deployXERC20(_name, _symbol, _minterLimits, _burnerLimits, _bridges, _freezingEnabled);
 
     emit XERC20Deployed(_xerc20);
   }
@@ -91,7 +92,8 @@ contract XERC20Factory is IXERC20Factory {
     string memory _symbol,
     uint256[] memory _minterLimits,
     uint256[] memory _burnerLimits,
-    address[] memory _bridges
+    address[] memory _bridges,
+    bool _freezingEnabled
   ) internal returns (address _xerc20) {
     uint256 _bridgesLength = _bridges.length;
     if (_minterLimits.length != _bridgesLength || _burnerLimits.length != _bridgesLength) {
@@ -99,7 +101,7 @@ contract XERC20Factory is IXERC20Factory {
     }
     bytes32 _salt = keccak256(abi.encodePacked(_name, _symbol, msg.sender));
     bytes memory _creation = type(XERC20).creationCode;
-    bytes memory _bytecode = abi.encodePacked(_creation, abi.encode(_name, _symbol, address(this)));
+    bytes memory _bytecode = abi.encodePacked(_creation, abi.encode(_name, _symbol, address(this), _freezingEnabled));
 
     _xerc20 = CREATE3.deploy(_salt, _bytecode, 0);
 

--- a/solidity/src/interfaces/IXERC20Factory.sol
+++ b/solidity/src/interfaces/IXERC20Factory.sol
@@ -57,7 +57,8 @@ interface IXERC20Factory {
         string memory _symbol,
         uint256[] memory _minterLimits,
         uint256[] memory _burnerLimits,
-        address[] memory _bridges
+        address[] memory _bridges,
+        bool _freezingEnabled
     ) external returns (address _xerc20);
 
     /**

--- a/solidity/test/forge/Adapter.t.sol
+++ b/solidity/test/forge/Adapter.t.sol
@@ -27,6 +27,7 @@ contract AdapterTest is Test, Helper {
         string memory name = "Token A";
         string memory symbol = "TKNA";
         uint256 supply = 100 ether;
+        bool freezingEnabled = false;
         bool local = true;
         ERC20 erc20 = ERC20(new ERC20Test(name, symbol, supply));
         (XERC20 xerc20, , ) = _setupXERC20(
@@ -34,7 +35,8 @@ contract AdapterTest is Test, Helper {
             address(erc20),
             string.concat("p", name),
             string.concat("p", symbol),
-            local
+            local,
+            freezingEnabled
         );
         FeesManager feesManager = new FeesManager(securityCouncil);
         PAM pam = new PAM();

--- a/solidity/test/forge/DeployHelper.sol
+++ b/solidity/test/forge/DeployHelper.sol
@@ -20,7 +20,8 @@ contract DeployHelper {
         address erc20,
         string memory name,
         string memory symbol,
-        bool local
+        bool local,
+        bool freezingEnabled
     ) internal returns (XERC20, XERC20Lockbox, XERC20Factory) {
         bytes32 _salt = keccak256(abi.encodePacked(SALT, msg.sender));
 
@@ -34,7 +35,8 @@ contract DeployHelper {
                 symbol,
                 emptyMintingLimits,
                 emptyBurningLimits,
-                emptyBridges
+                emptyBridges,
+                freezingEnabled
             )
         );
 

--- a/solidity/test/forge/FeesManager.t.sol
+++ b/solidity/test/forge/FeesManager.t.sol
@@ -44,6 +44,8 @@ contract FeesManagerTest is Test, Helper {
     uint256 tokenAmount_B = 2 ether;
     uint256 tokenAmount_ether = 3 ether;
 
+    bool freezingEnabled = false;
+
     EnumerableMap.AddressToUintMap tokensBalances;
 
     XERC20 xerc20_A;
@@ -62,7 +64,8 @@ contract FeesManagerTest is Test, Helper {
         XERC20 xerc20 = new XERC20(
             string.concat("p", name),
             string.concat("p", symbol),
-            owner
+            owner,
+            freezingEnabled
         );
 
         xerc20.setLimits(owner, supply, supply);

--- a/solidity/test/forge/Helper.sol
+++ b/solidity/test/forge/Helper.sol
@@ -71,7 +71,8 @@ abstract contract Helper is Test, DeployHelper {
         uint256 chain,
         address owner_,
         address erc20,
-        bool local
+        bool local,
+        bool freezingEnabled
     )
         internal
         returns (
@@ -91,7 +92,8 @@ abstract contract Helper is Test, DeployHelper {
             erc20,
             string.concat("p", erc20Name),
             string.concat("p", erc20Symbol),
-            local
+            local,
+            freezingEnabled
         );
 
         pam = new PAM();

--- a/solidity/test/forge/Integration.t.sol
+++ b/solidity/test/forge/Integration.t.sol
@@ -61,6 +61,8 @@ contract IntegrationTest is Test, Helper {
     IAdapter.Operation operation;
     IPAM.Metadata metadata;
 
+    bool freezingEnabled = false;
+
     constructor() {
         owner_A = vm.addr(1);
         user = vm.addr(2);
@@ -78,14 +80,16 @@ contract IntegrationTest is Test, Helper {
             CHAIN_A,
             owner_A,
             address(erc20),
-            LOCAL
+            LOCAL,
+            freezingEnabled
         );
 
         (xerc20_B, lockbox_B, adapter_B, feesManager_B, pam_B) = _setupChain(
             CHAIN_B,
             owner_B,
             address(erc20),
-            NOT_LOCAL
+            NOT_LOCAL,
+            freezingEnabled
         );
 
         _transferToken(address(erc20), owner_A, user, userBalance);

--- a/solidity/test/forge/PAM.t.sol
+++ b/solidity/test/forge/PAM.t.sol
@@ -55,7 +55,8 @@ contract PAMTest is Test, Helper {
             originChainId,
             owner,
             address(erc20),
-            true
+            true,
+            false
         );
 
         _transferToken(address(erc20), owner, user, 50000);

--- a/solidity/test/forge/Upgrade.t.sol
+++ b/solidity/test/forge/Upgrade.t.sol
@@ -59,9 +59,10 @@ contract Upgrade is Test {
         Options memory opts;
         Upgrades.validateUpgrade(contractName, opts);
 
+        bool freezingEnabled = false;
         bytes memory data = abi.encodeCall(
             XERC20PTokenCompat.initializeV2,
-            (owner)
+            (owner, freezingEnabled)
         );
 
         uint256[] memory balances = new uint256[](holders.length);

--- a/solidity/test/forge/XERC20.t.sol
+++ b/solidity/test/forge/XERC20.t.sol
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {EnumerableMap} from "@openzeppelin/contracts/utils/structs/EnumerableMap.sol";
+
+import {Vm} from "forge-std/Vm.sol";
+import {Helper} from "./Helper.sol";
+import {Test, stdMath} from "forge-std/Test.sol";
+
+import {PAM} from "../../src/contracts/PAM.sol";
+import {Adapter} from "../../src/contracts/Adapter.sol";
+import {XERC20} from "../../src/contracts/XERC20.sol";
+import {XERC20} from "../../src/contracts/XERC20.sol";
+import {XERC20Factory} from "../../src/contracts/XERC20Factory.sol";
+import {ERC20Test} from "../../src/contracts/test/ERC20Test.sol";
+import {FeesManager} from "../../src/contracts/FeesManager.sol";
+
+import "forge-std/console.sol";
+
+contract XERC20Test is Test, Helper {
+    XERC20 xerc20;
+    address freezingAddress = vm.addr(123123);
+
+    error ERC20InsufficientAllowance(
+        address spender,
+        uint256 allowance,
+        uint256 needed
+    );
+
+    function setUp() public {
+        vm.startPrank(owner);
+        string memory name = "xToken A";
+        string memory symbol = "xTKNA";
+        uint256 mintingLimit = 10000 ether;
+        uint256 burningLimit = 20000 ether;
+        uint256 supply = 100 ether;
+        bool freezingEnabled = true;
+        bool local = true;
+
+        bytes32 _salt = keccak256(abi.encodePacked(SALT, msg.sender));
+
+        XERC20Factory factory = new XERC20Factory{salt: _salt}();
+
+        xerc20 = XERC20(
+            factory.deployXERC20(
+                name,
+                symbol,
+                emptyMintingLimits,
+                emptyBurningLimits,
+                emptyBridges,
+                freezingEnabled
+            )
+        );
+
+        xerc20.setLimits(owner, mintingLimit, burningLimit);
+
+        vm.stopPrank();
+    }
+
+    function test_should_deploy_with_freezeEnabled_true() public {
+        vm.startPrank(owner);
+
+        assertTrue(xerc20.freezingEnabled());
+
+        vm.stopPrank();
+    }
+
+    function test_should_revertWhen_freezerAddressIsNotSet() public {
+        bytes memory errMsg = bytes("Freezing address is not set");
+
+        vm.startPrank(owner);
+        vm.expectRevert(errMsg);
+        xerc20.freezeAddress(evil);
+
+        vm.expectRevert(errMsg);
+        xerc20.unfreezeAddress(evil);
+
+        vm.expectRevert(errMsg);
+        xerc20.withdrawFrozenAssets(evil, owner, 10);
+
+        vm.stopPrank();
+    }
+
+    function test_setFreezingAddress_revertWhen_callerIsNotOwner() public {
+        vm.prank(evil);
+        _expectOwnableUnauthorizedAccountRevert(evil);
+        xerc20.setFreezingAddress(owner);
+
+        vm.prank(owner);
+        xerc20.setFreezingAddress(freezingAddress);
+
+        assertEq(xerc20.freezingAddress(), freezingAddress);
+    }
+
+    function test_should_freezeAddress() public {
+        vm.prank(owner);
+        xerc20.setFreezingAddress(freezingAddress);
+
+        vm.startPrank(freezingAddress);
+        xerc20.freezeAddress(evil);
+
+        assertTrue(xerc20.frozen(evil));
+
+        xerc20.unfreezeAddress(evil);
+
+        assertFalse(xerc20.frozen(evil));
+
+        vm.stopPrank();
+    }
+
+    // NOTE: testing freeze/unfreeze operations on an address
+    // called evil. Firstly we freeze the address and expect
+    // that neither a normal transfer either a transfer throug
+    // approval can happen from that evil address
+    //
+    // Finally we unfreeze the address and test the above
+    // transfers can again work as expected as nothing
+    // happened
+    function test_should_revertWhen_transferFromFrozenAddress() public {
+        address exchange = vm.addr(111);
+        uint256 stolenAmount = 10 ether;
+        vm.prank(owner);
+        xerc20.mint(user, 100 ether);
+
+        vm.prank(owner);
+        xerc20.setFreezingAddress(freezingAddress);
+
+        vm.prank(user);
+        xerc20.transfer(evil, stolenAmount);
+
+        vm.prank(freezingAddress);
+        xerc20.freezeAddress(evil);
+
+        vm.prank(evil);
+        vm.expectRevert(bytes("owner is frozen"));
+        xerc20.transfer(exchange, stolenAmount);
+
+        // Transfer through approval
+        address evilOtherAddress = vm.addr(54321);
+        vm.prank(evil);
+        xerc20.approve(evilOtherAddress, stolenAmount);
+
+        vm.prank(evilOtherAddress);
+        vm.expectRevert(bytes("owner is frozen"));
+        xerc20.transferFrom(evil, exchange, stolenAmount);
+
+        vm.prank(freezingAddress);
+        xerc20.unfreezeAddress(evil);
+
+        vm.startPrank(evil);
+        xerc20.transfer(exchange, stolenAmount - 10);
+
+        assertEq(xerc20.balanceOf(exchange), stolenAmount - 10);
+
+        xerc20.approve(evilOtherAddress, stolenAmount);
+        vm.stopPrank();
+
+        // Transfer through approve
+        vm.prank(evilOtherAddress);
+        xerc20.transferFrom(evil, exchange, 10);
+
+        assertEq(xerc20.balanceOf(exchange), stolenAmount);
+    }
+
+    function test_should_withdrawFrozenAssets() public {
+        uint256 stolenAmount = 100 ether;
+        vm.startPrank(owner);
+        xerc20.setFreezingAddress(freezingAddress);
+        xerc20.setLimits(owner, stolenAmount, stolenAmount);
+        xerc20.mint(evil, stolenAmount);
+        vm.stopPrank();
+
+        assertEq(xerc20.balanceOf(evil), stolenAmount);
+
+        vm.startPrank(freezingAddress);
+        xerc20.freezeAddress(evil);
+        xerc20.withdrawFrozenAssets(evil, freezingAddress, stolenAmount);
+        vm.stopPrank();
+
+        assertEq(xerc20.balanceOf(evil), 0);
+        assertEq(xerc20.balanceOf(freezingAddress), stolenAmount);
+    }
+}

--- a/solidity/test/hardhat/XERC20-freezing.test.js
+++ b/solidity/test/hardhat/XERC20-freezing.test.js
@@ -145,6 +145,14 @@ const deployERC1820 = () => helpers.setCode(ERC1820, ERC1820BYTES)
         ).to.be.revertedWith('recipient is frozen')
       })
 
+      it("Freezing address can't withdraw more than frozen's balance", async () => {
+        await expect(
+          pTokenV2
+            .connect(freezingAddress)
+            .withdrawFrozenAssets(evil, freezingAddress, amount + 10),
+        ).to.be.revertedWith('ERC20: transfer amount exceeds balance')
+      })
+
       it('Should withdraw from the frozen address succesfully', async () => {
         await expect(
           pTokenV2

--- a/solidity/test/hardhat/XERC20-freezing.test.js
+++ b/solidity/test/hardhat/XERC20-freezing.test.js
@@ -1,0 +1,181 @@
+import helpers, { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
+import { expect } from 'chai'
+import hre from 'hardhat'
+
+import ERC1820BYTES from './bytecodes/ERC1820.cjs'
+import { deployProxy } from './utils/deploy-proxy.cjs'
+import { getUpgradeOpts } from './utils/get-upgrade-opts.cjs'
+import { upgradeProxy } from './utils/upgrade-proxy.cjs'
+
+const ERC1820 = '0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24'
+const deployERC1820 = () => helpers.setCode(ERC1820, ERC1820BYTES)
+
+;['', 'NoGSN'].map(_useGSN => {
+  describe(`XERC20 ${_useGSN} - Freezing Tests`, () => {
+    const setup = async () => {
+      const [
+        owner,
+        admin,
+        minter,
+        recipient,
+        user,
+        evil,
+        bridge,
+        freezingAddress,
+      ] = await hre.ethers.getSigners()
+      const name = 'pToken A'
+      const symbol = 'pTKN A'
+      const originChainId = '0x10000000'
+
+      await deployERC1820()
+
+      const pToken = await deployProxy(hre, `PToken${_useGSN}`, admin, [
+        name,
+        symbol,
+        owner.address,
+        originChainId,
+      ])
+
+      const freezingEnabled = true
+      const opts = getUpgradeOpts(owner, freezingEnabled)
+      const pTokenV2 = await upgradeProxy(
+        hre,
+        pToken,
+        `XERC20PToken${_useGSN}Compat`,
+        opts,
+        admin,
+      )
+
+      const mintingLimit = 10000
+      const burningLimit = 10000
+      await pTokenV2.connect(owner).setLimits(owner, mintingLimit, burningLimit)
+
+      return {
+        owner,
+        admin,
+        minter,
+        recipient,
+        user,
+        evil,
+        bridge,
+        pTokenV2,
+        freezingAddress,
+      }
+    }
+
+    describe('Cumulative tests', () => {
+      let owner, recipient, user, evil, pTokenV2, freezingAddress
+      const amount = 10
+      before(async () => {
+        const obj = await loadFixture(setup)
+        owner = obj.owner
+        recipient = obj.recipient
+        user = obj.user
+        evil = obj.evil
+        pTokenV2 = obj.pTokenV2
+        freezingAddress = obj.freezingAddress
+      })
+
+      it('Freeze flag should be enabled', async () => {
+        expect(await pTokenV2.freezingEnabled()).to.be.true
+      })
+
+      it('Should transfer tokens successfully when not Frozen', async () => {
+        await pTokenV2.connect(owner).mint(evil, amount)
+        await pTokenV2.connect(evil).transfer(recipient, amount)
+
+        expect(await pTokenV2.balanceOf(evil)).to.be.equal(0)
+        expect(await pTokenV2.balanceOf(recipient)).to.be.equal(amount)
+      })
+
+      it('Only the owner can set the freezing address', async () => {
+        await expect(
+          pTokenV2.connect(evil).setFreezingAddress(freezingAddress),
+        ).to.be.revertedWith('Ownable: caller is not the owner')
+      })
+
+      it('Should set the freezing address successfully', async () => {
+        await expect(
+          pTokenV2.connect(owner).setFreezingAddress(freezingAddress),
+        ).to.not.be.reverted
+        expect(await pTokenV2.freezingAddress()).to.be.equal(freezingAddress)
+      })
+
+      it('Only freezing address can freeze, unfreeze and withdraw', async () => {
+        await expect(
+          pTokenV2.connect(owner).freezeAddress(evil),
+        ).to.be.revertedWith('Only freezing address allowed')
+
+        await expect(
+          pTokenV2.connect(owner).unfreezeAddress(evil),
+        ).to.be.revertedWith('Only freezing address allowed')
+
+        await expect(
+          pTokenV2.connect(owner).withdrawFrozenAssets(evil, owner, amount),
+        ).to.be.revertedWith('Only freezing address allowed')
+      })
+
+      it('Should freeze an address successfully', async () => {
+        await pTokenV2.connect(owner).mint(evil, amount) // stolen amount
+        await expect(pTokenV2.connect(freezingAddress).freezeAddress(evil)).to
+          .not.be.reverted
+
+        expect(await pTokenV2.frozen(evil)).to.be.true
+      })
+
+      it('Frozen address cannot transfer', async () => {
+        await expect(
+          pTokenV2.connect(evil).transfer(recipient, amount),
+        ).to.be.revertedWith('owner is frozen')
+      })
+
+      it('Frozen address cannot transfer through approval', async () => {
+        await pTokenV2.connect(evil).approve(recipient, amount)
+
+        await expect(
+          pTokenV2.connect(recipient).transferFrom(evil, recipient, amount),
+        ).to.be.revertedWith('owner is frozen')
+      })
+
+      it('Frozen address cannot receive assets', async () => {
+        await pTokenV2.connect(owner).mint(recipient, amount)
+
+        await expect(
+          pTokenV2.connect(recipient).transfer(evil, amount),
+        ).to.be.revertedWith('recipient is frozen')
+      })
+
+      it('Should withdraw from the frozen address succesfully', async () => {
+        await expect(
+          pTokenV2
+            .connect(freezingAddress)
+            .withdrawFrozenAssets(evil, freezingAddress, amount),
+        ).to.not.be.reverted
+
+        expect(await pTokenV2.balanceOf(evil)).to.be.equal(0)
+        expect(await pTokenV2.balanceOf(freezingAddress)).to.be.equal(amount)
+      })
+
+      it('Should unfreeze an address successfully', async () => {
+        await expect(pTokenV2.connect(freezingAddress).unfreezeAddress(evil)).to
+          .not.be.reverted
+
+        expect(await pTokenV2.frozen(evil)).to.be.false
+      })
+
+      it('Unfrozen address can transfer again', async () => {
+        await pTokenV2.connect(owner).mint(evil, amount)
+
+        const balancePre = await pTokenV2.balanceOf(recipient)
+
+        await expect(pTokenV2.connect(evil).transfer(recipient, amount)).to.not
+          .be.reverted
+
+        expect(await pTokenV2.balanceOf(evil)).to.be.equal(0)
+        expect(await pTokenV2.balanceOf(recipient)).to.be.equal(
+          balancePre + BigInt(amount),
+        )
+      })
+    })
+  })
+})

--- a/solidity/test/hardhat/XERC20PTokenCompat.test.js
+++ b/solidity/test/hardhat/XERC20PTokenCompat.test.js
@@ -130,16 +130,17 @@ const deployERC1820 = () => helpers.setCode(ERC1820, ERC1820BYTES)
 
         it('Should revert when trying to call initializeV2', async () => {
           const initError = 'Initializable: contract is already initialized'
+          const freezingEnabled = false
           await expect(
-            pTokenV2.connect(admin).initializeV2(evil),
+            pTokenV2.connect(admin).initializeV2(evil, freezingEnabled),
           ).to.be.revertedWith(initError)
 
           await expect(
-            pTokenV2.connect(owner).initializeV2(evil),
+            pTokenV2.connect(owner).initializeV2(evil, freezingEnabled),
           ).to.be.revertedWith(initError)
 
           await expect(
-            pTokenV2.connect(evil).initializeV2(evil),
+            pTokenV2.connect(evil).initializeV2(evil, freezingEnabled),
           ).to.be.revertedWith(initError)
         })
 

--- a/solidity/test/hardhat/forked-environment/ptoken-upgrade.test.js
+++ b/solidity/test/hardhat/forked-environment/ptoken-upgrade.test.js
@@ -33,7 +33,7 @@ const ADDRESS_PNETWORK_SIGNER = '0x341aA660fD5c280F5a9501E3822bB4a98E816D1b'
 const conditionalDescribe = process.env['FORK'] ? describe : describe.skip
 
 conditionalDescribe(
-  'Forked testsing - PToken v1 upgrade on BSC and subsequent pegout to Ethereum',
+  'Forked Testing - PToken v1 upgrade on BSC and subsequent pegout to Ethereum',
   () => {
     const oneEth = hre.ethers.toBeHex(hre.ethers.parseEther('1'))
     const mintingLimit = hre.ethers.parseEther('500000')
@@ -73,7 +73,7 @@ conditionalDescribe(
       let ptoken, proxyAdminOwner, ptokenv2
       before(async () => {
         const rpc = hre.config.networks.bscFork.url
-        const blockToForkFrom = 40729521 // 2024-07-23 15:22
+        const blockToForkFrom = 43336397 // 2024-10-22 09:25
         await helpers.reset(rpc, blockToForkFrom)
 
         user = await hre.ethers.getImpersonatedSigner(

--- a/solidity/test/hardhat/utils/get-upgrade-opts.cjs
+++ b/solidity/test/hardhat/utils/get-upgrade-opts.cjs
@@ -1,3 +1,6 @@
-module.exports.getUpgradeOpts = _owner => ({
-  call: { fn: 'initializeV2(address)', args: [_owner.address] },
+module.exports.getUpgradeOpts = (_owner, _freezingEnabled = false) => ({
+  call: {
+    fn: 'initializeV2(address, bool)',
+    args: [_owner.address, _freezingEnabled],
+  },
 })

--- a/solidity/test/hardhat/utils/xerc20-factory-deploy.cjs
+++ b/solidity/test/hardhat/utils/xerc20-factory-deploy.cjs
@@ -9,13 +9,20 @@ const factoryDeploy = (_hre, _factory, _methodName, _args = []) =>
     .then(R.prop('args'))
     .then(R.prop(0))
 
-const deployXERC20 = (_hre, _factory, _name, _symbol) =>
+const deployXERC20 = (
+  _hre,
+  _factory,
+  _name,
+  _symbol,
+  _freezingEnabled = false,
+) =>
   factoryDeploy(_hre, _factory, 'deployXERC20', [
     _name,
     _symbol,
     [],
     [],
     [],
+    _freezingEnabled,
   ]).then(_address => _hre.ethers.getContractAt('XERC20', _address))
 
 const deployXERC20Lockbox = (_hre, _factory, _xerc20, _erc20, _isNative) =>


### PR DESCRIPTION
#### Notes & observations: 
 - `XERC20.sol` diffs must be audited now
 - On EOS there's only one freezing accoung for all the tokens supported by the contract
 - On EOS, if freezing account isn't defined then the freezing features are not enabled (there isn't a boolean flag as done on EVM)
 - On EVM the boolean freezingEnabled can be set only upon contract deployment, while on EOS can be enabled or disabled through the setting of the `freezing_account` singleton