### PR TITLE
Fix #37 (4/4)

### DIFF
--- a/solidity/src/contracts/Adapter.sol
+++ b/solidity/src/contracts/Adapter.sol
@@ -30,14 +30,19 @@ contract Adapter is IAdapter, Ownable, ReentrancyGuard {
     address public pam;
     uint256 public minFee;
     mapping(bytes32 => bool) public pastEvents;
+    bool public isNative;
 
     constructor(
         address xerc20_,
         address erc20_,
+        bool isNative_,
         address feesManager_,
         address pam_
     ) Ownable(msg.sender) {
-        erc20 = erc20_;
+        isNative = isNative_;
+        if (!isNative) {
+            erc20 = erc20_;
+        }
         xerc20 = xerc20_;
         feesManager = feesManager_;
         pam = pam_;
@@ -124,7 +129,7 @@ contract Adapter is IAdapter, Ownable, ReentrancyGuard {
         string memory recipient,
         bytes memory data
     ) external payable {
-        if (erc20 == address(0)) {
+        if (erc20 == address(0) && isNative) {
             _swapNative(destinationChainId, recipient, data);
         } else {
             _swapToken(token, amount, destinationChainId, recipient, data);

--- a/solidity/test/forge/Adapter.t.sol
+++ b/solidity/test/forge/Adapter.t.sol
@@ -43,6 +43,7 @@ contract AdapterTest is Test, Helper {
         adapter = new Adapter(
             address(xerc20),
             address(erc20),
+            notNative,
             address(feesManager),
             address(pam)
         );

--- a/solidity/test/forge/Helper.sol
+++ b/solidity/test/forge/Helper.sol
@@ -105,6 +105,7 @@ abstract contract Helper is Test, DeployHelper {
         adapter = new Adapter(
             address(xerc20),
             address(erc20),
+            notNative,
             address(feesManager),
             address(pam)
         );

--- a/solidity/test/hardhat/Adapter.test.js
+++ b/solidity/test/hardhat/Adapter.test.js
@@ -82,6 +82,7 @@ const deployERC1820 = () => setCode(ERC1820, ERC1820BYTES)
         const adapter = await deploy(hre, 'Adapter', [
           pTokenV2.target,
           erc20.target,
+          _isNative,
           feesManager,
           PAM,
         ])

--- a/solidity/test/hardhat/forked-environment/ptoken-upgrade.test.js
+++ b/solidity/test/hardhat/forked-environment/ptoken-upgrade.test.js
@@ -45,6 +45,7 @@ conditionalDescribe(
     const burningLimit = hre.ethers.parseEther('500000')
     const swapAmount = hre.ethers.parseEther('10000')
     const userdata = '0x'
+    const isNative = false
 
     let erc20,
       adapterEth,
@@ -93,6 +94,7 @@ conditionalDescribe(
         adapterBsc = await deploy(hre, 'Adapter', [
           ptoken.target,
           ADDRESS_ERC20_TOKEN,
+          isNative,
           feesManagerBsc,
           pamBsc,
         ])
@@ -179,7 +181,6 @@ conditionalDescribe(
 
         const name = `p${await erc20.name()}`
         const symbol = `p${await erc20.symbol()}`
-        const isNative = false
 
         const factory = await deploy(hre, 'XERC20Factory', [])
         xerc20 = await deployXERC20(hre, factory, name, symbol)
@@ -204,6 +205,7 @@ conditionalDescribe(
         adapterEth = await deploy(hre, 'Adapter', [
           xerc20.target,
           ADDRESS_ERC20_TOKEN,
+          isNative,
           feesManagerEth,
           pamEth,
         ])


### PR DESCRIPTION
Introduce a native flag on the EVM contracts in order to distinguish among the native asset wrapping and a token on a non-local chain.