### PR TITLE
Add unwrapping/unlock test on local deployment

### DIFF
--- a/cpp/contracts/adapter.cpp
+++ b/cpp/contracts/adapter.cpp
@@ -55,7 +55,7 @@ void adapter::create(
    }
 
    // Default value for the token symbol on non-local deployments
-   symbol non_local_token_symbol = symbol(symbol_code("XXX"), token_symbol.precision());
+   symbol non_local_token_symbol = symbol(symbol_code("XXX"), 0);
 
    adapter_registry_table registry_data {
       .token = token,

--- a/cpp/contracts/adapter.cpp
+++ b/cpp/contracts/adapter.cpp
@@ -251,8 +251,7 @@ void adapter::settle(const name& caller, const operation& operation, const metad
    name xerc20 = registry_data.xerc20;
    check(is_account(xerc20), "Not valid xerc20 name");
    if (operation.amount > 0) {
-      asset adj_operation_amount = adjust_precision(operation.amount, registry_data.token_symbol, registry_data.xerc20_symbol);
-      asset quantity(adj_operation_amount.amount, registry_data.xerc20_symbol);
+      asset quantity = adjust_precision(operation.amount, registry_data.xerc20_symbol);
       lockbox_singleton _lockbox(xerc20, xerc20.value);
       action_mint _mint(registry_data.xerc20, {get_self(), "active"_n});
       if (_lockbox.exists()) {

--- a/cpp/contracts/utils.hpp
+++ b/cpp/contracts/utils.hpp
@@ -131,20 +131,13 @@ namespace eosio {
       return asset(amount / powint(10, exp), sym);
    }
 
-   asset adjust_precision(uint128_t amount, const symbol& from_symbol, const symbol& to_symbol) {
-      int16_t exp = from_symbol.precision() - to_symbol.precision();
-      uint128_t factor;
-      uint128_t adjusted_amount;
-      if (exp < 0) {
-         exp = -exp;
-         factor = powint(10, exp);
-         adjusted_amount = amount * factor;
-      } else {
-         print("WARNING: Operation precision exceeds destination symbol; amount will be floored to destination symbol precision.");
-         factor = powint(10, exp);
-         adjusted_amount = amount / factor;
-      }
-      return asset(adjusted_amount, to_symbol);
+   asset adjust_precision(uint128_t amount, const symbol& target) {
+      check(target.precision() <= 18, "invalid precision");
+      int16_t exp = 18 - target.precision();
+
+      uint128_t adjusted_amount = amount / powint(10, exp);
+
+      return asset(adjusted_amount, target);
    }
 
    bytes extract_32bytes(const bytes& data, uint128_t offset) {

--- a/cpp/test/adapter-local.test.js
+++ b/cpp/test/adapter-local.test.js
@@ -1,6 +1,6 @@
 const R = require('ramda')
 const { expect } = require('chai')
-const { Asset, Name } = require('@wharfkit/antelope')
+const { Asset } = require('@wharfkit/antelope')
 const { Blockchain, expectToThrow, nameToBigInt } = require('@eosnetwork/vert')
 const { deploy } = require('./utils/deploy')
 const {

--- a/cpp/test/adapter-non-local.test.js
+++ b/cpp/test/adapter-non-local.test.js
@@ -145,7 +145,7 @@ describe('Adapter Testing - Non Local Deployment', () => {
       token: '0x810090f35dfa6b18b5eb59d298e2a2443a2811e2',
       originChainId: evmOriginChainId,
       destinationChainId: Chains(Protocols.Eos).Mainnet,
-      amount: Number(parseEther(String(evmSwapAmount))),
+      amount: evmSwapAmount, // Number(parseEther(String())),
       sender:
         '000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
       recipient,

--- a/cpp/test/adapter-non-local.test.js
+++ b/cpp/test/adapter-non-local.test.js
@@ -145,7 +145,7 @@ describe('Adapter Testing - Non Local Deployment', () => {
       token: '0x810090f35dfa6b18b5eb59d298e2a2443a2811e2',
       originChainId: evmOriginChainId,
       destinationChainId: Chains(Protocols.Eos).Mainnet,
-      amount: evmSwapAmount, // Number(parseEther(String())),
+      amount: evmSwapAmount,
       sender:
         '000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
       recipient,
@@ -232,14 +232,14 @@ describe('Adapter Testing - Non Local Deployment', () => {
       )
 
       expect(after[recipient][xerc20.symbol]).to.be.deep.equal(
-        Asset.from(evmSwapAmount, xsymbolPrecision).toString(),
+        Asset.from(evmSwapAmount, xsymbolPrecision),
       )
 
       expect(after[adapter.account][xerc20.symbol]).to.be.deep.equal(
-        Asset.from(0, xsymbolPrecision).toString(),
+        Asset.from(0, xsymbolPrecision),
       )
 
-      expect(before[feemanager][xerc20.symbol]).to.be.equal(
+      expect(before[feemanager][xerc20.symbol]).to.be.deep.equal(
         after[feemanager][xerc20.symbol],
       )
     })
@@ -276,15 +276,12 @@ describe('Adapter Testing - Non Local Deployment', () => {
         [xerc20],
       )
 
-      expect(after[recipient][xerc20.symbol]).to.equal(
-        sum(
-          Asset.from(evmSwapAmount, xsymbolPrecision),
-          beforeAsset,
-        ).toString(),
+      expect(after[recipient][xerc20.symbol]).to.be.deep.equal(
+        sum(Asset.from(evmSwapAmount, xsymbolPrecision), beforeAsset),
       )
 
-      expect(after[adapter.account][xerc20.symbol]).to.be.equal(
-        Asset.from(0, xsymbolPrecision).toString(),
+      expect(after[adapter.account][xerc20.symbol]).to.be.deep.equal(
+        Asset.from(0, xsymbolPrecision),
       )
     })
 
@@ -332,7 +329,7 @@ describe('Adapter Testing - Non Local Deployment', () => {
       ).to.be.deep.equal(adjusted)
 
       expect(after[adapter.account][xerc20.symbol]).to.be.deep.equal(
-        Asset.from(0, xsymbolPrecision).toString(),
+        Asset.from(0, xsymbolPrecision),
       )
     })
   })
@@ -361,7 +358,7 @@ describe('Adapter Testing - Non Local Deployment', () => {
       ).to.be.deep.equal(quantity)
 
       expect(after[adapter.account][xerc20.symbol]).to.be.deep.equal(
-        Asset.from(0, xsymbolPrecision).toString(),
+        Asset.from(0, xsymbolPrecision),
       )
 
       const expectedEventBytes =

--- a/cpp/test/pam.test.js
+++ b/cpp/test/pam.test.js
@@ -342,6 +342,7 @@ describe('PAM testing', () => {
 
     it('Should authorize an EOSIO operation successfully', async () => {
       let eosOperation = getOperation({
+        local: true,
         nonce: 0,
         blockId:
           '179ed57f474f446f2c9f6ea6702724cdad0cf26422299b368755ed93c0134a35',
@@ -397,9 +398,9 @@ describe('PAM testing', () => {
         .isauthorized([eosOperation, eosMetadata])
         .send(active(user))
 
-      expect(pam.contract.bc.console).to.be.equal(
-        'ff57d8865411fe30f3a29259c17ad16f613bf8fc4ec18269a4ea6c991448d2b6',
-      )
+      const expectedEventId =
+        '190635fc5b0d1b2704567e7a1d379dcf9604119fded50de105a1e77f381d3a0e'
+      expect(pam.contract.bc.console).to.be.equal(expectedEventId)
     })
   })
 })

--- a/cpp/test/pam.test.js
+++ b/cpp/test/pam.test.js
@@ -12,14 +12,11 @@ const {
   bytes32,
   getOperation,
   getMetadataSample,
-  getOperationSample,
   fromEthersPublicKey,
 } = require('./utils')
 const { expect } = require('chai')
-const { parseEther } = require('ethers')
 const { active, getSingletonInstance } = require('./utils/eos-ext')
 const { serializeOperation } = require('./utils/get-operation-sample')
-const { UInt128 } = require('@wharfkit/antelope')
 
 describe('PAM testing', () => {
   const user = 'user'
@@ -64,7 +61,7 @@ describe('PAM testing', () => {
     token: '0xf2e246bb76df876cef8b38ae84130f4f55de395b',
     originChainId: Chains(Protocols.Evm).Mainnet,
     destinationChainId: Chains(Protocols.Eos).Mainnet,
-    amount: Number(parseEther(String(evmSwapAmount))),
+    amount: evmSwapAmount,
     sender: '0x2b5ad5c4795c026514f8317c7a215e218dccd6cf',
     recipient,
     data: '',
@@ -352,7 +349,7 @@ describe('PAM testing', () => {
         token: '4,TKN',
         originChainId: Chains(Protocols.Eos).Jungle,
         destinationChainId: Chains(Protocols.Eos).Mainnet,
-        amount: 9982500000000000000,
+        amount: 9.9825,
         sender: 'user',
         recipient: 'recipient',
         data: '',

--- a/cpp/test/utils/errors.js
+++ b/cpp/test/utils/errors.js
@@ -75,6 +75,8 @@ const CONTRACT_ALREADY_INITIALIZED = eosio_assert(
 
 const GRACE_PERIOD_NOT_ELAPSED = eosio_assert('grace period not elapsed')
 
+const EVENT_ALREADY_PROCESSED = eosio_assert('event already processed')
+
 module.exports = {
   AUTH_MISSING,
   SYMBOL_NOT_FOUND,
@@ -111,4 +113,5 @@ module.exports = {
   INVALID_PAYLOAD,
   CONTRACT_ALREADY_INITIALIZED,
   GRACE_PERIOD_NOT_ELAPSED,
+  EVENT_ALREADY_PROCESSED,
 }

--- a/cpp/test/utils/get-operation-sample.js
+++ b/cpp/test/utils/get-operation-sample.js
@@ -1,6 +1,6 @@
 const R = require('ramda')
-const { toBeHex, concat, stripZerosLeft } = require('ethers')
-const { Asset, UInt128 } = require('@wharfkit/antelope')
+const { UInt128 } = require('@wharfkit/antelope')
+const { toBeHex, concat, stripZerosLeft, parseEther } = require('ethers')
 const { _0x, no0x, bytes32 } = require('./bytes-utils')
 const { Protocols, Chains } = require('@pnetwork/event-attestator')
 const { getSymbolCodeRaw } = require('./eos-ext')
@@ -35,7 +35,7 @@ const getOperation = _obj => {
     : bytes32(_0x(_obj.token))
   const destinationChainId = bytes32(_0x(_obj.destinationChainId))
 
-  const amount = UInt128.from(_obj.amount.toString())
+  const amount = UInt128.from(String(parseEther(String(_obj.amount))))
 
   const sender = isEosChain(_obj.originChainId)
     ? bytes32(_0x(Buffer.from(_obj.sender, 'utf-8').toString('hex')))

--- a/cpp/test/utils/get-operation-sample.js
+++ b/cpp/test/utils/get-operation-sample.js
@@ -26,8 +26,12 @@ const isEosChain = _chainId =>
   R.values(Chains(Protocols.Eos)).includes(stripZerosLeft(_chainId))
 
 const getOperation = _obj => {
-  const blockId = bytes32(_0x(_obj.blockId))
-  const txId = bytes32(_0x(_obj.txId))
+  const defaultBlockId =
+    '0x7e21ba208ea2a072bad2d011dbc3a9f870c574a66203d84bde926fcf85756d78'
+  const defaultTxId =
+    '0x2e3704b180feda25af9dfe50793e292fd99d644aa505c3d170fa69407091dbd3'
+  const blockId = bytes32(_0x(_obj.blockId || defaultBlockId))
+  const txId = bytes32(_0x(_obj.txId || defaultTxId))
   const nonce = _obj.nonce
   const originChainId = bytes32(_0x(_obj.originChainId))
   const token = isEosChain(_obj.originChainId)
@@ -41,7 +45,7 @@ const getOperation = _obj => {
     ? bytes32(_0x(Buffer.from(_obj.sender, 'utf-8').toString('hex')))
     : bytes32(_obj.sender)
   const recipient = _obj.recipient
-  const data = _0x(_obj.data)
+  const data = _0x(_obj.data || '')
 
   return {
     blockId,

--- a/cpp/test/utils/get-operation-sample.js
+++ b/cpp/test/utils/get-operation-sample.js
@@ -43,7 +43,6 @@ const getOperation = _obj => {
   const destinationChainId = bytes32(_0x(_obj.destinationChainId))
 
   const amount = String(parseEther(String(_obj.amount))) // UInt128.from()
-  console.log('amount', amount)
   const sender = isEosChain(_obj.originChainId)
     ? bytes32(_0x(Buffer.from(_obj.sender, 'utf-8').toString('hex')))
     : bytes32(_obj.sender)

--- a/cpp/test/utils/get-operation-sample.js
+++ b/cpp/test/utils/get-operation-sample.js
@@ -26,6 +26,7 @@ const isEosChain = _chainId =>
   R.values(Chains(Protocols.Eos)).includes(stripZerosLeft(_chainId))
 
 const getOperation = _obj => {
+  const local = _obj.local || false
   const defaultBlockId =
     '0x7e21ba208ea2a072bad2d011dbc3a9f870c574a66203d84bde926fcf85756d78'
   const defaultTxId =
@@ -34,13 +35,15 @@ const getOperation = _obj => {
   const txId = bytes32(_0x(_obj.txId || defaultTxId))
   const nonce = _obj.nonce
   const originChainId = bytes32(_0x(_obj.originChainId))
-  const token = isEosChain(_obj.originChainId)
-    ? bytes32(toBeHex(_0x(String(getSymbolCodeRaw(_obj.token)))))
-    : bytes32(_0x(_obj.token))
+
+  const token =
+    local && isEosChain(_obj.destinationChainId)
+      ? bytes32(_0x(Number(getSymbolCodeRaw(_obj.token)).toString(16)))
+      : bytes32(_0x(_obj.token))
   const destinationChainId = bytes32(_0x(_obj.destinationChainId))
 
-  const amount = UInt128.from(String(parseEther(String(_obj.amount))))
-
+  const amount = String(parseEther(String(_obj.amount))) // UInt128.from()
+  console.log('amount', amount)
   const sender = isEosChain(_obj.originChainId)
     ? bytes32(_0x(Buffer.from(_obj.sender, 'utf-8').toString('hex')))
     : bytes32(_obj.sender)
@@ -61,6 +64,8 @@ const getOperation = _obj => {
   }
 }
 
+// From an operation extract the relative
+// event payload
 const serializeOperation = _operation => {
   const amount = bytes32(toBeHex(BigInt(_operation.amount.toString())))
   const recipientLen = bytes32(

--- a/cpp/test/utils/get-token-balance.js
+++ b/cpp/test/utils/get-token-balance.js
@@ -22,7 +22,7 @@ const getAccountsBalances = (_accounts, _tokensAndSymbol) => {
         account,
         token.symbol,
         token.decimals,
-      ).toString()
+      )
     }
   }
 

--- a/cpp/test/xerc20.token.freezing.test.js
+++ b/cpp/test/xerc20.token.freezing.test.js
@@ -6,6 +6,7 @@ const { active, getAccountCodeRaw, precision } = require('./utils/eos-ext')
 const errors = require('./utils/errors')
 const { substract } = require('./utils/wharfkit-ext')
 const { getAccountsBalances } = require('./utils/get-token-balance')
+const { Asset } = require('@wharfkit/antelope')
 
 TABLE_FREEZING_ACCOUNT = 'freezeacc'
 
@@ -114,8 +115,8 @@ describe('xerc20.token - Freezing capabilities tests', () => {
 
       let balances = getAccountsBalances([evil, recipient], [xerc20])
 
-      expect(balances[recipient][xerc20.symbol]).to.be.equal(
-        transfereableAmount.toString(),
+      expect(balances[recipient][xerc20.symbol]).to.be.deep.equal(
+        transfereableAmount,
       )
 
       await xerc20.contract.actions.freeze([evil]).send(active(freezingAccount))
@@ -148,8 +149,12 @@ describe('xerc20.token - Freezing capabilities tests', () => {
 
       const after = getAccountsBalances([evil, freezingAccount], [xerc20])
 
-      expect(after[evil][xerc20.symbol]).to.be.equal(`0.0000 ${xerc20.symbol}`)
-      expect(after[freezingAccount][xerc20.symbol]).to.be.equal(stolenAmount)
+      expect(after[evil][xerc20.symbol]).to.be.deep.equal(
+        Asset.from(0, precision(4, xerc20.symbol)),
+      )
+      expect(after[freezingAccount][xerc20.symbol]).to.be.deep.equal(
+        Asset.from(stolenAmount),
+      )
     })
 
     it('Should unfreeze an account successfully', async () => {


### PR DESCRIPTION
 - Simplify `adjust_precision` upon settlement (keep fixed `18` decimals regardless)
 - Add test for unlocking the wrapped asset on local deployments
 - Add test for replay attack