### PR TITLE
chore(cpp): fix #81

### DIFF
--- a/cpp/contracts/utils.hpp
+++ b/cpp/contracts/utils.hpp
@@ -122,6 +122,8 @@ namespace eosio {
    }
 
    uint128_t to_wei(asset quantity) {
+      // We don't need overflow checks here since they are enforced at protocol
+      // level, see https://github.com/AntelopeIO/spring/blob/v1.1.1/libraries/chain/symbol.cpp#L16
       const uint8_t exp = 18 - quantity.symbol.precision();
       return quantity.amount * powint(10, exp);
    }


### PR DESCRIPTION
No check is needed since the precision is enforced at protocol level, that means that no Antelope asset can be created with more than 18 decimals. Reference [here](https://github.com/AntelopeIO/spring/blob/v1.1.1/libraries/chain/symbol.cpp#L16)


We put a comment in the code with the above reference for posterity
