### PR TITLE
fix audit issue 5

### DIFF
--- a/cpp/contracts/adapter.cpp
+++ b/cpp/contracts/adapter.cpp
@@ -130,7 +130,7 @@ void adapter::adduserdata(const name& caller, bytes payload) {
    // instead of a singleton because we can
    // scope it by account value.
    // Singletons doesn't support scoping and they
-   // are global througout the contract
+   // are global throughout the contract
    if (table.begin() == table.end()) {
       table.emplace(caller, [&](auto& r) {
           r.id = 1;
@@ -146,11 +146,13 @@ void adapter::adduserdata(const name& caller, bytes payload) {
 
 void adapter::freeuserdata(const name& account) {
    require_auth(account);
-   user_data table(account, account.value);
+   user_data table(get_self(), account.value);
 
-   for (auto itr = table.begin(); itr != table.end(); itr++) {
+   // We expect one single element in the table
+   // see comment in adduserdata
+   auto itr = table.begin();
+   if (itr != table.end())
       table.erase(itr);
-   }
 }
 
 void adapter::setchainid(bytes chain_id) {

--- a/cpp/test/adapter-local.test.js
+++ b/cpp/test/adapter-local.test.js
@@ -380,7 +380,21 @@ describe('Adapter Testing - Local deployment', () => {
         expect(R.last(rows).payload).to.be.equal(data)
       })
 
+      it('Should free userdata successfully', async () => {
+        await adapter.contract.actions.freeuserdata([user]).send(active(user))
+
+        const rows = adapter.contract.tables
+          .userdata(nameToBigInt(user))
+          .getTableRows()
+
+        expect(rows.length).to.be.equal(0)
+      })
+
       it('Should send user data successfully', async () => {
+        await adapter.contract.actions
+          .adduserdata([user, data])
+          .send(active(user))
+
         await token.contract.actions
           .transfer([user, adapter.account, quantity, memo])
           .send(active(user))


### PR DESCRIPTION
- When calling `adapter::freeuserdata` it uses the `get_self()` account for accessing the table
- For loop has been removed since it isn't needed as the table has just one single row and erasing it within the loop was causing an error due to the in-place changes
- Added a test for `adapter::freeuserdata`